### PR TITLE
one potential bug fix and some qol improvements

### DIFF
--- a/controllers/Builder.php
+++ b/controllers/Builder.php
@@ -143,7 +143,7 @@ class Builder extends \Admin\Classes\AdminController
 
             // catch-all
             if (stripos($field, '.') === false)
-                $field = $tableName.'.'.$field;
+                $field = $model->getTable().'.'.$field;
 
             return $query->where($field, $operator, $value, $condition);
 
@@ -201,6 +201,15 @@ class Builder extends \Admin\Classes\AdminController
             $writer = Writer::createFromString();
             $writer->insertOne($csv_headings);
             $writer->insertAll(new \ArrayIterator($data->toArray()));
+
+            // this will set the file to download properly for most use-cases, but there is a known limitation with Excel on macOS (see https://csv.thephpleague.com/9.0/interoperability/encoding/)
+            header('Content-Encoding: UTF-8');
+            header('Content-Type: application/csv; charset=UTF-8');
+            header('Content-Disposition: attachment; filename='.str_replace(' ', '_', $model->title).'.csv');
+            header('Pragma: no-cache');
+
+            $writer->setOutputBOM(Writer::BOM_UTF8);
+            $writer->addStreamFilter('convert.iconv.ISO-8859-15/UTF-8');
 
             echo $writer->getContent();
             exit();

--- a/language/en/default.php
+++ b/language/en/default.php
@@ -40,6 +40,13 @@ return [
         'label_orders_type' => 'Type',
         'label_orders_address' => 'Address',
 
+        'label_orders_date_relative' => 'Order Date Relative',
+        'value_date_relative_7' => '7 days',
+        'value_date_relative_14' => '14 days',
+        'value_date_relative_30' => '30 days',
+        'value_date_relative_90' => '90 days',
+        'value_date_relative_365' => '365 days',
+
         'text_title' => 'Query Builder',
     ],
 


### PR DESCRIPTION
The only bug addressed here is L146, where using the default order date filter uses the catch-all `->where`, and thus gives you this error

```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'ti_ti_orders.order_date' in 'where clause' 
```
using 'orders' there instead of 'ti_orders' seems to fix it. 

The rest is just QOL improvements, and I'll leave it up to you whether you want to merge any of this in (I suppose some people would rather just see the CSV rather than have to load up Excel or something). 