### PR TITLE
thoughtco.reports.extendQuery needs to fire here or else extended columns won't show up on CSV

### DIFF
--- a/controllers/Builder.php
+++ b/controllers/Builder.php
@@ -184,6 +184,9 @@ class Builder extends \Admin\Classes\AdminController
 
             $table = $klass->newQuery();
             $query = $parser->parse(json_encode($model->builderjson['rules']), $table);
+
+            $this->fireSystemEvent('thoughtco.reports.extendQuery', [$query, $model->builderjson['model']] );
+
             $data = $query->get();
 
             $csv_columns = [];


### PR DESCRIPTION
Pretty much what it says on the tin - currently the CSV shows blank columns for anything added through `thoughtco.reports.extendQuery` since the CSV output block doesn't run through ReportsTable (where the event is firing normally). 