### PR TITLE
Update Builder.php

### DIFF
--- a/controllers/Builder.php
+++ b/controllers/Builder.php
@@ -225,7 +225,7 @@ class Builder extends \Admin\Classes\AdminController
         $sort_column = '';
         foreach ($model->list_columns as $list_col) {
             $col = json_decode($list_col['column'], true);
-            $list_columns[$col['key']] = [
+            $col['key'] = [
                 'title' => $list_col['label'],
             ];
             if ($sort_column == '')


### PR DESCRIPTION
Getting error in the query builder section. The View page of the Query Builder is not appearing. with the small change, you can fix the issue. 
Please check this query:
SELECT COUNT(*) AS AGGREGATE FROM
    `ti_customers`
INNER JOIN `ti_order_menus` ON `ti_order_menus`.`order_id` = `ti_orders`.`order_id`
LEFT JOIN `ti_addresses` ON `ti_addresses`.`address_id` = `ti_customers`.`address_id`
WHERE  `ti_customers`.`date_added`>="2022-03-19 11:53:14";

"date_added" column doesn't exist on ti_customers table.